### PR TITLE
Adding export-content deliverable to project

### DIFF
--- a/Chauffeur.ContentImport/Chauffeur.ContentImport.csproj
+++ b/Chauffeur.ContentImport/Chauffeur.ContentImport.csproj
@@ -230,6 +230,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="ContentExportDeliverable.cs" />
     <Compile Include="ContentImportDeliverable.cs" />
     <Compile Include="ContentPublishDeliverable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Chauffeur.ContentImport/ContentExportDeliverable.cs
+++ b/Chauffeur.ContentImport/ContentExportDeliverable.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Chauffeur.Host;
+using Umbraco.Core.Services;
+
+namespace Chauffeur.ContentImport
+{
+    [DeliverableName("content-export")]
+    public class ContentExportDeliverable : Deliverable
+    {
+        private readonly IFileSystem fileSystem;
+        private readonly IChauffeurSettings settings;
+        private readonly IPackagingService packagingService;
+        private readonly IContentService contentService;
+
+        public ContentExportDeliverable(
+            TextReader reader,
+            TextWriter writer,
+            IFileSystem fileSystem,
+            IChauffeurSettings settings,
+            IPackagingService packagingService,
+            IContentService contentService)
+            : base(reader, writer)
+        {
+            this.fileSystem = fileSystem;
+            this.settings = settings;
+            this.packagingService = packagingService;
+            this.contentService = contentService;
+        }
+
+        public override async Task<DeliverableResponse> Run(string command, string[] args)
+        {
+            if (!args.Any())
+            {
+                await Out.WriteLineAsync("No packages were provided, use `help content-export` to see usage");
+                return DeliverableResponse.Continue;
+            }
+
+            string chauffeurFolder;
+            if (!settings.TryGetChauffeurDirectory(out chauffeurFolder))
+                return DeliverableResponse.Continue;
+
+            var tasks = args.Select(arg => Pack(arg, chauffeurFolder));
+            await Task.WhenAll(tasks);
+
+            return DeliverableResponse.Continue;
+        }
+
+        private async Task Pack(string name, string chauffeurFolder)
+        {
+            var fileLocation = fileSystem.Path.Combine(chauffeurFolder, name + ".xml");
+            if (fileSystem.File.Exists(fileLocation))
+            {
+                await Out.WriteLineAsync($"The package '{name}' already in the Chauffeur folder");
+                return;
+            }
+
+            await Out.WriteLineAsync($"Exporting content to {name}.xml");
+
+            var content = contentService.GetRootContent();
+
+            var xml = new XDocument();
+            xml.Add(new XElement("umbPackage",
+                new XElement("Documents",
+                    new XElement("DocumentSet",
+                        content.Select(c => packagingService.Export(c, true)), new XAttribute("importMode", "root")
+                    )
+                )
+            ));
+            
+            settings.TryGetChauffeurDirectory(out string dir);
+            fileSystem.File.WriteAllText(fileSystem.Path.Combine(dir, $"{name}.xml"), xml.ToString());
+
+            await Out.WriteLineAsync($"Content have been exported to {name}");
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,12 @@ The Umbraco Packaging API allows you to import and publish content through it, t
 
 This will look for a file (sans `.xml` extension) which is an Umbraco Package and will import the content from within it.
 
+## `content-export`
+
+    umbraco> content-export PackageName
+
+This will export an xml file which is an Umbraco Package containing the content of your site.
+
 ## `content-publish`
 
     umbraco> content-publish <?ids> -user=<userId> -children=true|false


### PR DESCRIPTION
As per the issue I raised on the [main Chauffeur project](https://github.com/aaronpowell/Chauffeur/issues/98), I've added an `export-content` deliverable to write content to file in the format of an Umbraco package.

If you've any feedback please give me a shout.

Thanks